### PR TITLE
layout tabelle fixed/links aktualisiert

### DIFF
--- a/testdaten.md
+++ b/testdaten.md
@@ -10,20 +10,17 @@
 
 | Land  			| GID6 Link | GID7 Link |
 |---|---|---|
-| Baden-Württemberg		|  | [https://www.lgl-bw.de/Produkte/Testdaten/Testdaten-Liegenschaftskataster/](https://www.lgl-bw.de/Produkte/Testdaten/Testdaten-Liegenschaftskataster/
-) | 
-| Bayern			| |[https://www.ldbv.bayern.de/produkte/testdaten/
-](https://www.ldbv.bayern.de/produkte/testdaten/
-)| 
-| Berlin-Brandenburg		| | [https://geobasis-bb.de/lgb/de/geodaten/liegenschaftskataster/geoinfodok-7-1](https://geobasis-bb.de/lgb/de/geodaten/liegenschaftskataster/geoinfodok-7-1) | 
+| Baden-Württemberg		|  | [https://www.lgl-bw.de/Produkte/Testdaten/Testdaten-Liegenschaftskataster/](https://www.lgl-bw.de/Produkte/Testdaten/Testdaten-Liegenschaftskataster/) | 
+| Bayern			| |[https://www.ldbv.bayern.de/produkte/testdaten/](https://www.ldbv.bayern.de/produkte/testdaten/)| 
+| Berlin			| | [https://www.berlin.de/sen/sbw/stadtdaten/geoinformation/liegenschaftskataster/geobasisdaten-online/neues/#alkis](https://www.berlin.de/sen/sbw/stadtdaten/geoinformation/liegenschaftskataster/geobasisdaten-online/neues/#alkis) | 
+| Brandenburg		| | [https://geobasis-bb.de/lgb/de/geodaten/liegenschaftskataster/geoinfodok-7-1](https://geobasis-bb.de/lgb/de/geodaten/liegenschaftskataster/geoinfodok-7-1) | 
+| Bremen			| | [https://www.geo.bremen.de/produkte/katasterprodukte/auszuege-aus-dem-liegenschaftskataster-12272](https://www.geo.bremen.de/produkte/katasterprodukte/auszuege-aus-dem-liegenschaftskataster-12272) | 
 | Hessen			| | [https://hvbg.hessen.de/geoinformation/afis-alkis-atkis-modell/geoinfodok-neu](https://hvbg.hessen.de/geoinformation/afis-alkis-atkis-modell/geoinfodok-neu) | 
 | Mecklenburg-Vorpommern	| | FAQ siehe MV ALKIS – Umstellung auf AAA-AS 7.1 [https://www.laiv-mv.de/Geoinformation/FAQ/](https://www.laiv-mv.de/Geoinformation/FAQ/) | 
-| Niedersachsen		| [http://www.lgn.niedersachsen.de/portal/live.php?navigation_id=11043&article_id=51644&_psmand=35](http://www.lgn.niedersachsen.de/portal/live.php?navigation_id=11043&article_id=51644&_psmand=35) | [https://www.lgln.niedersachsen.de/startseite/geodaten_karten/afis_alkis_atkis/aaa_testdaten/testdaten-220074.html](https://www.lgln.niedersachsen.de/startseite/geodaten_karten/afis_alkis_atkis/aaa_testdaten/testdaten-220074.html) | 
+| Niedersachsen		| [http://www.lgn.niedersachsen.de/portal/live.php?navigation_id=11043&article_id=51644&_psmand=35](http://www.lgn.niedersachsen.de/portal/live.php?navigation_id=11043&article_id=51644&_psmand=35) | [https://lgln-geodaten.niedersachsen.de/startseite/geodaten_karten/afis_alkis_atkis/aaa_testdaten/testdaten-220074.html](https://lgln-geodaten.niedersachsen.de/startseite/geodaten_karten/afis_alkis_atkis/aaa_testdaten/testdaten-220074.html) |
 | Rheinland-Pfalz		| | 
 | Saarland			| | [https://www.saarland.de/lvgl/DE/themen-aufgaben/themen/kataster/alkis/alkis.html](https://www.saarland.de/lvgl/DE/themen-aufgaben/themen/kataster/alkis/alkis.html) | 
 | Sachsen-Anhalt		|  |[https://www.lvermgeo.sachsen-anhalt.de/de/gdp-testdaten-geobasisdaten.html](https://www.lvermgeo.sachsen-anhalt.de/de/gdp-testdaten-geobasisdaten.html) | 
 | Sachsen			|  | [https://www.landesvermessung.sachsen.de/infos-und-testdaten-4020.html](https://www.landesvermessung.sachsen.de/infos-und-testdaten-4020.html)  |
 | Schleswig-Holstein		| | [http://www.schleswig-holstein.de/DE/Landesregierung/LVERMGEOSH/Downloads/DownloadTestdaten/downloadsTestdatenAlkis.html](http://www.schleswig-holstein.de/DE/Landesregierung/LVERMGEOSH/Downloads/DownloadTestdaten/downloadsTestdatenAlkis.html)  | 
-| Thüringen			|  | [https://tlbg.thueringen.de/](https://tlbg.thueringen.de/) im Bereich "Online-Shop / Vertrieb" dort direkt unter dem Thema "Testdaten" | 
-| Bremen			| | [https://www.geo.bremen.de/produkte/katasterprodukte/auszuege-aus-dem-liegenschaftskataster-12272](https://www.geo.bremen.de/produkte/katasterprodukte/auszuege-aus-dem-liegenschaftskataster-12272) | 
-| Berlin			| | [https://www.berlin.de/sen/sbw/stadtdaten/geoportal/liegenschaftskataster/alkis/](https://www.berlin.de/sen/sbw/stadtdaten/geoportal/liegenschaftskataster/alkis/) | 
+| Thüringen			|  | [https://tlbg.thueringen.de/online-shop-vertrieb/testdaten#c86225](https://tlbg.thueringen.de/online-shop-vertrieb/testdaten#c86225) |


### PR DESCRIPTION
defekte umbrüche angepasst, berlin und brandenburg getrennt, reihenfolge der bundesländer alphabetisch geordnet, links zu gid7 für niedersachsen aktualisiert, link zu gid7 für thüringen aktualisiert, link zu gid7 für berlin aktualisiert